### PR TITLE
Add missing translation in :ca and :es

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,4 +1,8 @@
 ca:
+  activemodel:
+    attributes:
+      organization:
+        admin_terms_of_use_body: Cos dels termes d'ús dels administradors
   forms:
     length_validator:
       # This translation should have been updated at Decidim 0.25

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,10 @@
 es:
+  activemodel:
+    attributes:
+      organization:
+        # This translation should have been added at Decidim 0.24
+        # if it's already there, remove it from here
+        admin_terms_of_use_body: Cuerpo de los términos de uso de los administradores
   forms:
     length_validator:
       # This translation should have been updated at Decidim 0.25


### PR DESCRIPTION
The translation `activemodel.attributes.organization.admin_terms_of_use_body` still is missing in Decidim for :ca and :es.
This PR adds it to the application while it's missing in Decidim.